### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "rlang"
+run = "r skypemafia.R"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ of mentioned players at sources such as Crunchbase, AngelList, LinkedIn, etc.
 
 Data collection should be relatively easy to replicate for whatever group of people and companies you're
 interested in if you were to fork this script. Use at your own risk.
+
+[![Run on Repl.it](https://repl.it/badge/github/stamkivi/SkypeMafia-visualization)](https://repl.it/github/stamkivi/SkypeMafia-visualization)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).